### PR TITLE
Fix release version copy and paste error

### DIFF
--- a/fix-appdata.patch
+++ b/fix-appdata.patch
@@ -64,7 +64,7 @@ index 416e135..c5a1b71 100644
 +  </developer>
 +  <update_contact>pw@goatattack.net</update_contact>
    <releases>
-+    <release version="0.4.5" date="2024-04-29">
++    <release version="0.5.0" date="2024-04-29">
 +      <url>https://github.com/goatattack/goatattack/releases/tag/0.5.0</url>
 +    </release>
      <release version="0.4.5" date="2017-09-14" />


### PR DESCRIPTION
Displays the wrong version at https://flathub.org/apps/net.goatattack.goatattack